### PR TITLE
Add id/umask as hidden settings

### DIFF
--- a/MeTube.xml
+++ b/MeTube.xml
@@ -14,7 +14,7 @@
   <WebUI>http://[IP]:[PORT:8081]</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/Zazou49/unraid/main/MeTube.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/alexta69/metube/master/favicon/android-chrome-384x384.png</Icon>
-  <ExtraParams>--user 99:100</ExtraParams>
+  <ExtraParams/>
   <PostArgs/>
   <CPUset/>
   <DateInstalled>1630783884</DateInstalled>
@@ -49,4 +49,7 @@
   <Config Name="WebUI" Target="8081" Default="" Mode="tcp" Description="Container Port: 8081" Type="Port" Display="always" Required="true" Mask="false">8081</Config>
   <Config Name="Downloads" Target="/downloads" Default="" Mode="rw" Description="Container Path: /downloads" Type="Path" Display="always" Required="true" Mask="false"/>
   <Config Name="Outpout Template" Target="OUTPUT_TEMPLATE" Default="%(title)s.%(ext)s" Mode="" Description="You can check all tags here: https://github.com/ytdl-org/youtube-dl/blob/master/README.md#output-template" Type="Variable" Display="always" Required="true" Mask="false">%(channel)s/%(title)s.%(ext)s</Config>
+  <Config Name="User ID" Target="UID" Default="99" Mode="" Description="Container Variable: UID" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Group ID" Target="GID" Default="100" Mode="" Description="Container Variable: GID" Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="UMASK" Target="UMASK" Default="000" Mode="" Description="Container Variable: UMASK" Type="Variable" Display="advanced" Required="false" Mask="false"/>
 </Container>


### PR DESCRIPTION
MeTube doesn't use PUID/PGID nomenclature, instead uses UID/GID
Remove ExtraParams as no longer needed